### PR TITLE
Fix shooter bot orientation and yaw logic

### DIFF
--- a/src/assets/shooter_bot.js
+++ b/src/assets/shooter_bot.js
@@ -1,5 +1,6 @@
 // ShooterBot v2: compact biped with right-hand SMG
-// Faces +Z in object space. Gun fires along -Z.
+// Faces +Z in object space; gun also fires along +Z.
+// Earlier versions fired backward and needed a code-side π yaw flip.
 // Returns { root, head, refs: { gun, muzzle } }
 export function createShooterBot({ THREE, mats, scale = 1.0, palette } = {}) {
   const group = new THREE.Group();
@@ -66,10 +67,11 @@ export function createShooterBot({ THREE, mats, scale = 1.0, palette } = {}) {
   const hand = add(new THREE.Mesh(new THREE.BoxGeometry(0.24, 0.14, 0.20), matAccent),
                    rFore, new THREE.Vector3(0.16, -0.36, -0.12));
 
-  // -------- gun (−Z forward)
+  // -------- gun (+Z forward)
   const gun = new THREE.Group();
   rFore.add(gun);
   gun.position.set(0.22, -0.32, -0.28);
+  gun.rotation.y = Math.PI; // align muzzle with +Z
 
   // receiver + grip
   add(new THREE.Mesh(new THREE.BoxGeometry(0.28, 0.22, 0.60), matGun), gun, new THREE.Vector3(0, 0.04, -0.30));

--- a/src/enemies/shooter.js
+++ b/src/enemies/shooter.js
@@ -167,7 +167,7 @@ export class ShooterEnemy {
       this._faceDir.lerp(faceVec, lerpAmt);
       if (this._faceDir.lengthSq() > 0) this._faceDir.normalize();
     }
-    const desiredYaw = Math.atan2(this._faceDir.x, this._faceDir.z) + Math.PI; // -Z forward faces target
+    const desiredYaw = Math.atan2(this._faceDir.x, this._faceDir.z); // +Z forward faces target
     const wrap = (a)=>{ while(a>Math.PI) a-=2*Math.PI; while(a<-Math.PI) a+=2*Math.PI; return a; };
     let dy = wrap(desiredYaw - this._yaw);
     const turnRate = 5.0; // slightly reduced to smooth out jitter


### PR DESCRIPTION
## Summary
- Flip ShooterBot gun to face +Z and document new forward direction
- Remove 180° yaw hack so shooter uses standard +Z facing

## Testing
- `node --check src/assets/shooter_bot.js`
- `node --check src/enemies/shooter.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4d9839cd08322a1bb59efe0c1b202