### PR TITLE
feat: reward tank kills with extra drops

### DIFF
--- a/docs/gamedesign/mechanics.md
+++ b/docs/gamedesign/mechanics.md
@@ -40,6 +40,7 @@
   - Medkit: restores 20–35 HP (8–10% drop chance, capped per wave)
 - Magnet radius: small auto‑pickup when within ~1.2 units
 - Drop beacon VFX for visibility
+- Tank enemies always drop 3–4 random pickups, ignoring caps
 
 ### Hype Meter (Combo)
 - Base scoring: +100 kill, +150 headshot kill

--- a/src/pickups.js
+++ b/src/pickups.js
@@ -42,6 +42,20 @@ export class Pickups {
     return false;
   }
 
+  // Spawn multiple pickups at once, ignoring caps and pity timers.
+  // `type` can be 'ammo', 'med', or 'random' for a mix.
+  dropMultiple(type, pos, count) {
+    for (let i = 0; i < count; i++) {
+      const t = (type === 'random' || !type)
+        ? (Math.random() < 0.5 ? 'ammo' : 'med')
+        : type;
+      const p = pos.clone();
+      p.x += (Math.random() - 0.5) * 0.6;
+      p.z += (Math.random() - 0.5) * 0.6;
+      this.spawn(t, p);
+    }
+  }
+
   spawn(type, pos) {
     const THREE = this.THREE;
     const group = new THREE.Group();

--- a/src/weapons/dmr.js
+++ b/src/weapons/dmr.js
@@ -45,7 +45,12 @@ export class DMR extends Weapon {
       if (res.enemyRoot.userData.hp <= 0) {
         effects?.enemyDeath?.(res.enemyRoot.position.clone());
         if (S && S.enemyDeath) S.enemyDeath(res.enemyRoot?.userData?.type || 'grunt');
-        pickups?.maybeDrop?.(res.enemyRoot.position.clone());
+        const eType = res.enemyRoot?.userData?.type;
+        if (eType === 'tank') { // tanks shower extra rewards
+          pickups?.dropMultiple?.('random', res.enemyRoot.position.clone(), 3 + (Math.random() * 2 | 0));
+        } else {
+          pickups?.maybeDrop?.(res.enemyRoot.position.clone());
+        }
         enemyManager.remove(res.enemyRoot);
         const base = isHead ? 150 : 100;
         const finalScore = Math.round(base * (ctx.combo?.multiplier || 1));
@@ -71,7 +76,12 @@ export class DMR extends Weapon {
         if (S && S.enemyPain) S.enemyPain(res2.enemyRoot?.userData?.type || 'grunt');
         if (res2.enemyRoot.userData.hp <= 0) {
           effects?.enemyDeath?.(res2.enemyRoot.position.clone());
-          pickups?.maybeDrop?.(res2.enemyRoot.position.clone());
+          const eType2 = res2.enemyRoot?.userData?.type;
+          if (eType2 === 'tank') { // tanks shower extra rewards
+            pickups?.dropMultiple?.('random', res2.enemyRoot.position.clone(), 3 + (Math.random() * 2 | 0));
+          } else {
+            pickups?.maybeDrop?.(res2.enemyRoot.position.clone());
+          }
           enemyManager.remove(res2.enemyRoot);
           const base2s = isHead2 ? 150 : 100;
           const finalScore2 = Math.round(base2s * (ctx.combo?.multiplier || 1));

--- a/src/weapons/grenadepistol.js
+++ b/src/weapons/grenadepistol.js
@@ -82,7 +82,12 @@ export class GrenadePistol extends Weapon {
         root.userData.hp -= dmg;
         if (root.userData.hp <= 0){
           effects?.enemyDeath?.(root.position.clone());
-          pickups?.maybeDrop?.(root.position.clone());
+          const eType = root?.userData?.type;
+          if (eType === 'tank') { // tanks shower extra rewards
+            pickups?.dropMultiple?.('random', root.position.clone(), 3 + (Math.random() * 2 | 0));
+          } else {
+            pickups?.maybeDrop?.(root.position.clone());
+          }
           enemyManager.remove(root);
           const finalScore = Math.round(120 * (ctx.combo?.multiplier || 1));
           addScore?.(finalScore);

--- a/src/weapons/pistol.js
+++ b/src/weapons/pistol.js
@@ -51,7 +51,12 @@ export class Pistol extends Weapon {
       if (res.enemyRoot.userData.hp <= 0) {
         effects?.enemyDeath?.(res.enemyRoot.position.clone());
         if (S && S.enemyDeath) S.enemyDeath(res.enemyRoot?.userData?.type || 'grunt');
-        pickups?.maybeDrop?.(res.enemyRoot.position.clone());
+        const eType = res.enemyRoot?.userData?.type;
+        if (eType === 'tank') { // tanks shower extra rewards
+          pickups?.dropMultiple?.('random', res.enemyRoot.position.clone(), 3 + (Math.random() * 2 | 0));
+        } else {
+          pickups?.maybeDrop?.(res.enemyRoot.position.clone());
+        }
         enemyManager.remove(res.enemyRoot);
         const base = (res.isHead || res.bodyPart==='head') ? 150 : 100;
         const finalScore = Math.round(base * (ctx.combo?.multiplier || 1));

--- a/src/weapons/rifle.js
+++ b/src/weapons/rifle.js
@@ -75,7 +75,12 @@ export class Rifle extends Weapon {
       if (res.enemyRoot.userData.hp <= 0) {
         effects?.enemyDeath?.(res.enemyRoot.position.clone());
         if (S && S.enemyDeath) S.enemyDeath(res.enemyRoot?.userData?.type || 'grunt');
-        pickups?.maybeDrop?.(res.enemyRoot.position.clone());
+        const eType = res.enemyRoot?.userData?.type;
+        if (eType === 'tank') { // tanks shower extra rewards
+          pickups?.dropMultiple?.('random', res.enemyRoot.position.clone(), 3 + (Math.random() * 2 | 0));
+        } else {
+          pickups?.maybeDrop?.(res.enemyRoot.position.clone());
+        }
         enemyManager.remove(res.enemyRoot);
         const baseScore = isHead ? 150 : 100;
         const finalScore = Math.round(baseScore * (ctx.combo?.multiplier || 1));

--- a/src/weapons/shotgun.js
+++ b/src/weapons/shotgun.js
@@ -61,7 +61,12 @@ export class Shotgun extends Weapon {
         effects?.spawnBulletDecal?.(end, res.hitFace?.normal, { size: 0.09, ttl: 8, color: 0x1a1a1a, softness: 0.65, object: res.hitObject, owner: res.enemyRoot, attachTo: res.enemyRoot });
         if (res.enemyRoot.userData.hp <= 0) {
           effects?.enemyDeath?.(res.enemyRoot.position.clone());
-          pickups?.maybeDrop?.(res.enemyRoot.position.clone());
+          const eType = res.enemyRoot?.userData?.type;
+          if (eType === 'tank') { // tanks shower extra rewards
+            pickups?.dropMultiple?.('random', res.enemyRoot.position.clone(), 3 + (Math.random() * 2 | 0));
+          } else {
+            pickups?.maybeDrop?.(res.enemyRoot.position.clone());
+          }
           enemyManager.remove(res.enemyRoot);
           const base = (res.isHead || res.bodyPart==='head') ? 150 : 100;
           const finalScore = Math.round(base * (ctx.combo?.multiplier || 1));

--- a/src/weapons/smg.js
+++ b/src/weapons/smg.js
@@ -68,7 +68,12 @@ export class SMG extends Weapon {
       if (res.enemyRoot.userData.hp <= 0) {
         effects?.enemyDeath?.(res.enemyRoot.position.clone());
         if (S && S.enemyDeath) S.enemyDeath(res.enemyRoot?.userData?.type || 'grunt');
-        pickups?.maybeDrop?.(res.enemyRoot.position.clone());
+        const eType = res.enemyRoot?.userData?.type;
+        if (eType === 'tank') { // tanks shower extra rewards
+          pickups?.dropMultiple?.('random', res.enemyRoot.position.clone(), 3 + (Math.random() * 2 | 0));
+        } else {
+          pickups?.maybeDrop?.(res.enemyRoot.position.clone());
+        }
         enemyManager.remove(res.enemyRoot);
         const baseScore = isHead ? 150 : 100;
         const finalScore = Math.round(baseScore * (ctx.combo?.multiplier || 1));


### PR DESCRIPTION
## Summary
- add `dropMultiple` helper to spawn several pickups at once
- weapon kill handlers give tank enemies 3–4 random drops
- document tank's guaranteed loot

## Testing
- `node --check src/pickups.js src/weapons/pistol.js src/weapons/smg.js src/weapons/rifle.js src/weapons/shotgun.js src/weapons/grenadepistol.js src/weapons/dmr.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4da20037c8322a74bed44cba94ded