### PR TITLE
Streamline music library for cohesive album

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [Play Now](https://oleksandrlynda.github.io/quarantine-of-joy-game/)
 
+[Music Player & Editor](https://oleksandrlynda.github.io/quarantine-of-joy-game/music_player.html) – preview tracks, tweak song data, and persist edits via browser localStorage
+
 Concepts:
 
 Game:

--- a/music_player.html
+++ b/music_player.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Music Player</title>
+  <link rel="stylesheet" href="styles/styles.css" />
+  <style>
+    body{ padding:20px; }
+    select, button{ margin:4px; }
+  </style>
+</head>
+<body>
+  <h1>Music Library Player</h1>
+  <div>
+    <label for="songSelect">Song:</label>
+    <select id="songSelect"></select>
+    <button id="playBtn">Play</button>
+    <button id="stopBtn">Stop</button>
+    <button id="muteBtn">Mute</button>
+    <label for="fadeDuration">Fade (s):</label>
+    <input type="number" id="fadeDuration" min="0" max="5" step="0.1" value="0.5" />
+  </div>
+  <progress id="songProgress" value="0" max="1" style="width:300px;"></progress>
+
+  <h2>Song Editor</h2>
+  <textarea id="songData" rows="12" cols="80"></textarea><br />
+  <button id="saveSong">Save Changes</button>
+  <button id="addSong">Add As New</button>
+  <button id="deleteSong">Delete Song</button>
+
+  <script type="module">
+    import { Music } from './src/music.js';
+    import { SONGS } from './src/musicLibrary.js';
+
+    const songSelect = document.getElementById('songSelect');
+    const songData = document.getElementById('songData');
+    const songProgress = document.getElementById('songProgress');
+
+    const STORAGE_KEY = 'musicLibrary';
+
+    function saveLibrary() {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(SONGS));
+      } catch (err) {
+        console.warn('Failed to save library', err);
+      }
+    }
+
+    function loadLibrary() {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (raw) {
+          const saved = JSON.parse(raw);
+          if (Array.isArray(saved)) {
+            SONGS.splice(0, SONGS.length, ...saved);
+          }
+        }
+      } catch (err) {
+        console.warn('Failed to load library', err);
+      }
+    }
+
+    function refreshSelect() {
+      songSelect.innerHTML = '';
+      SONGS.forEach(song => {
+        const opt = document.createElement('option');
+        opt.value = song.id;
+        opt.textContent = song.name || song.id;
+        songSelect.appendChild(opt);
+      });
+    }
+
+    function loadEditor() {
+      const song = SONGS.find(s => s.id === songSelect.value);
+      songData.value = song ? JSON.stringify(song, null, 2) : '';
+    }
+
+    loadLibrary();
+    refreshSelect();
+    loadEditor();
+
+    const music = new Music({ volume: 0.5 });
+    music.onStep = (step, stepsPerBar) => {
+      songProgress.value = (step + 1) / stepsPerBar;
+    };
+
+    function resetProgress() {
+      songProgress.value = 0;
+    }
+
+    function getFadeDuration() {
+      return parseFloat(document.getElementById('fadeDuration').value) || 0;
+    }
+
+    function fadeOut(duration) {
+      return new Promise(resolve => {
+        if (!music.masterGain || !music.ctx) {
+          music.stop();
+          resolve();
+          return;
+        }
+        const ctx = music.ctx;
+        const gain = music.masterGain.gain;
+        const now = ctx.currentTime;
+        gain.cancelScheduledValues(now);
+        gain.setValueAtTime(gain.value, now);
+        gain.linearRampToValueAtTime(0.0001, now + duration);
+        setTimeout(() => {
+          music.stop();
+          resolve();
+        }, duration * 1000);
+      });
+    }
+
+    function fadeIn(duration) {
+      if (!music.masterGain || !music.ctx) return;
+      const ctx = music.ctx;
+      const gain = music.masterGain.gain;
+      const now = ctx.currentTime;
+      const target = music.isMuted ? 0.0001 : music.volume;
+      gain.cancelScheduledValues(now);
+      gain.setValueAtTime(0.0001, now);
+      gain.linearRampToValueAtTime(target, now + duration);
+    }
+
+    document.getElementById('playBtn').onclick = async () => {
+      const song = SONGS.find(s => s.id === songSelect.value);
+      const fade = getFadeDuration();
+      await fadeOut(fade);
+      resetProgress();
+      music.loadSong(song);
+      music.start();
+      fadeIn(fade);
+    };
+
+    document.getElementById('stopBtn').onclick = () => {
+      const fade = getFadeDuration();
+      fadeOut(fade).then(resetProgress);
+    };
+
+    document.getElementById('muteBtn').onclick = () => {
+      const muted = !music.isMuted;
+      music.setMuted(muted);
+      document.getElementById('muteBtn').textContent = muted ? 'Unmute' : 'Mute';
+    };
+
+    songSelect.onchange = () => { loadEditor(); resetProgress(); };
+
+    document.getElementById('saveSong').onclick = () => {
+      try {
+        const updated = JSON.parse(songData.value);
+        const index = SONGS.findIndex(s => s.id === songSelect.value);
+        if (index >= 0) {
+          SONGS[index] = updated;
+          saveLibrary();
+          refreshSelect();
+          songSelect.value = updated.id;
+          loadEditor();
+          alert('Song updated');
+        }
+      } catch (err) {
+        alert('Invalid JSON');
+      }
+    };
+
+    document.getElementById('addSong').onclick = () => {
+      try {
+        const song = JSON.parse(songData.value);
+        if (!song.id) {
+          alert('Song must have an id');
+          return;
+        }
+        SONGS.push(song);
+        saveLibrary();
+        refreshSelect();
+        songSelect.value = song.id;
+        loadEditor();
+        alert('Song added');
+      } catch (err) {
+        alert('Invalid JSON');
+      }
+    };
+
+    document.getElementById('deleteSong').onclick = () => {
+      const index = SONGS.findIndex(s => s.id === songSelect.value);
+      if (index >= 0 && confirm('Delete this song?')) {
+        SONGS.splice(index, 1);
+        saveLibrary();
+        refreshSelect();
+        loadEditor();
+      }
+    };
+  </script>
+</body>
+</html>

--- a/src/music.js
+++ b/src/music.js
@@ -23,6 +23,7 @@ export class Music {
     this._timerId = null;
     this.barCounter = 0;
     this.secondsPerStep = 0;
+    this.onStep = null; // optional callback for playback progress
     this.swing = 0.12; // 0..0.5 of step; 0.12 = gentle swing
     this.energy = 0; // 0..3 from gameplay
     this.mode = 'normal'; // 'normal' | 'boss'
@@ -136,11 +137,14 @@ export class Music {
     const scheduler = () => {
       if (!this.isPlaying) return;
       while (this.nextNoteTime < this.ctx.currentTime + this.scheduleAheadTime) {
-        this.scheduleStep(this.currentStep, this.nextNoteTime);
+        const stepForCallback = this.currentStep;
+        this.scheduleStep(stepForCallback, this.nextNoteTime);
         this.nextNoteTime += secondsPerStep;
-        const prev = this.currentStep;
         this.currentStep = (this.currentStep + 1) % this.stepsPerBar;
-        if (prev === this.stepsPerBar - 1) this.barCounter++;
+        if (typeof this.onStep === 'function') {
+          this.onStep(stepForCallback, this.stepsPerBar);
+        }
+        if (stepForCallback === this.stepsPerBar - 1) this.barCounter++;
       }
     };
 

--- a/src/musicLibrary.js
+++ b/src/musicLibrary.js
@@ -1,5 +1,7 @@
 // Preset chiptune/8-bit drive songs for the playlist
-// Each song config customizes rhythm, harmony, tempo, and feel
+// Each song customizes rhythm, harmony, tempo, and feel
+// Drive A and Boss Standoff act as anchors while the other tracks
+// reference a shared motif for a cohesive album vibe
 
 export const SONGS = [
   {
@@ -15,79 +17,13 @@ export const SONGS = [
     leadArp: [0, 12, 7, 12],
     delayTime: 0.23,
   },
-  // Drive A variations (consistent vibe, different feel)
-  {
-    id: 'drive-a-boost',
-    name: 'Drive A — Boost',
-    bpm: 136,
-    swing: 0.11,
-    baseFreq: 164.81, // E3
-    progression: [0, 8, 5, 10, 0, 8, 10, 0],
-    kickPattern: [1,0,0,0, 1,0,1,0, 1,0,0,0, 1,0,1,0],
-    snarePattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0],
-    hatPattern:   [1,1,1,0, 1,0,1,1, 1,1,1,0, 1,0,1,1],
-    leadArp: [0, 12, 7, 14],
-    delayTime: 0.21,
-  },
-  {
-    id: 'drive-a-chill',
-    name: 'Drive A — Chill',
-    bpm: 124,
-    swing: 0.16,
-    baseFreq: 164.81, // E3
-    progression: [0, 8, 3, 10, 0, 8, 10, 0],
-    kickPattern: [1,0,0,0, 0,0,1,0, 1,0,0,0, 0,0,1,0],
-    snarePattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0],
-    hatPattern:   [1,0,0,1, 1,0,1,0, 1,0,0,1, 1,0,1,0],
-    leadArp: [0, 12, 5, 12],
-    delayTime: 0.27,
-  },
-  {
-    id: 'drive-a-f-minor',
-    name: 'Drive A — F minor',
-    bpm: 132,
-    swing: 0.12,
-    baseFreq: 174.61, // F3
-    progression: [0, 8, 3, 10, 0, 8, 10, 0],
-    kickPattern: [1,0,0,0, 1,0,0,0, 1,0,0,0, 1,0,0,0],
-    snarePattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0],
-    hatPattern:   [1,0,1,0, 1,0,1,0, 1,0,1,0, 1,0,1,0],
-    leadArp: [0, 12, 7, 12],
-    delayTime: 0.23,
-  },
-  {
-    id: 'drive-a-sync',
-    name: 'Drive A — Syncopated',
-    bpm: 134,
-    swing: 0.1,
-    baseFreq: 164.81, // E3
-    progression: [0, 8, 3, 10, 0, 8, 10, 0],
-    kickPattern: [1,0,0,0, 1,0,0,1, 1,0,0,0, 1,0,0,1],
-    snarePattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0],
-    hatPattern:   [1,0,1,1, 1,0,1,0, 1,0,1,1, 1,0,1,0],
-    leadArp: [0, 12, 7, 19],
-    delayTime: 0.2,
-  },
-  {
-    id: 'drive-a-dirt',
-    name: 'Drive A — Dirt',
-    bpm: 138,
-    swing: 0.09,
-    baseFreq: 164.81, // E3
-    progression: [0, 8, 5, 10, 0, 8, 10, 0],
-    kickPattern: [1,0,1,0, 1,0,1,0, 1,0,1,0, 1,0,1,0],
-    snarePattern: [0,0,0,0, 1,0,0,1, 0,0,0,0, 1,0,0,1],
-    hatPattern:   [1,1,1,1, 1,0,1,1, 1,1,1,1, 1,0,1,1],
-    leadArp: [0, 12, 7, 15],
-    delayTime: 0.18,
-  },
   {
     id: 'drive-b',
     name: 'Drive B',
     bpm: 136,
     swing: 0.1,
     baseFreq: 174.61, // F3
-    progression: [0, 7, 5, 3, 0, 10, 7, 5], // Fm C Bb Ab | Fm Eb C Bb
+    progression: [0, 8, 3, 10, 0, 7, 10, 0], // Fm Db Ab Eb | Fm C Eb Fm
     kickPattern: [1,0,0,0, 1,0,0,0, 1,0,0,1, 0,0,0,0], // small variation
     snarePattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0],
     hatPattern:   [1,0,1,1, 1,0,1,0, 1,0,1,1, 1,0,1,0], // busier
@@ -100,7 +36,7 @@ export const SONGS = [
     bpm: 124,
     swing: 0.16,
     baseFreq: 155.56, // D#3/Eb3
-    progression: [0, 10, 3, 8, 0, 10, 8, 0], // Ebm Db Gbm B | Ebm Db B Ebm
+    progression: [0, 8, 3, 10, 0, 10, 8, 0], // Ebm Cb Ab Db | Ebm Db Cb Ebm
     kickPattern: [1,0,0,0, 0,0,1,0, 1,0,0,0, 0,0,1,0],
     snarePattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0],
     hatPattern:   [1,0,0,1, 1,0,0,1, 1,0,0,1, 1,0,0,1], // syncopated
@@ -113,7 +49,7 @@ export const SONGS = [
     bpm: 140,
     swing: 0.08,
     baseFreq: 146.83, // D3
-    progression: [0, 7, 10, 5, 0, 7, 3, 0], // Dm A C G | Dm A F Dm
+    progression: [0, 8, 3, 10, 0, 7, 3, 0], // Dm C G Bb | Dm C F Dm
     kickPattern: [1,0,0,0, 1,0,1,0, 1,0,0,0, 1,0,1,0],
     snarePattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0],
     hatPattern:   [1,1,1,0, 1,0,1,1, 1,1,1,0, 1,0,1,1],
@@ -141,7 +77,7 @@ export const SONGS = [
     bpm: 134,
     swing: 0.1,
     baseFreq: 164.81, // E3
-    progression: [0, 5, 3, 10, 0, 5, 7, 3], // Em Am G D | Em Am Bm G
+    progression: [0, 8, 3, 10, 0, 5, 7, 3], // Em C G D | Em A B G
     kickPattern: [1,0,0,0, 1,0,1,0, 1,0,0,1, 0,0,0,0],
     snarePattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0],
     hatPattern:   [1,0,1,0, 1,1,1,0, 1,0,1,0, 1,1,1,0],
@@ -154,7 +90,7 @@ export const SONGS = [
     bpm: 126,
     swing: 0.14,
     baseFreq: 174.61, // F3
-    progression: [0, 10, 5, 3, 0, 7, 5, 3], // Fm Eb Bb Ab | Fm C Bb Ab
+    progression: [0, 8, 3, 10, 0, 7, 5, 3], // Fm Db Ab Eb | Fm C Bb Ab
     kickPattern: [1,0,1,0, 1,0,0,0, 1,0,1,0, 1,0,0,0],
     snarePattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0],
     hatPattern:   [1,0,0,1, 1,0,1,0, 1,0,0,1, 1,0,1,0],
@@ -167,7 +103,7 @@ export const SONGS = [
     bpm: 142,
     swing: 0.08,
     baseFreq: 155.56, // Eb3
-    progression: [0, 7, 10, 5, 0, 10, 7, 0], // Ebm Bb Db Ab | Ebm Db Bb Ebm
+    progression: [0, 8, 3, 10, 0, 10, 7, 0], // Ebm Cb Ab Db | Ebm Db Bb Ebm
     kickPattern: [1,0,0,0, 1,0,1,0, 1,0,0,0, 1,0,1,0],
     snarePattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0],
     hatPattern:   [1,1,1,0, 1,0,1,1, 1,1,1,0, 1,0,1,1],
@@ -180,7 +116,7 @@ export const SONGS = [
     bpm: 120,
     swing: 0.18,
     baseFreq: 146.83, // D3
-    progression: [0, 10, 3, 7, 0, 10, 7, 0], // Dm C F A | Dm C A Dm
+    progression: [0, 8, 3, 10, 0, 10, 5, 0], // Dm C G Bb | Dm C F Dm
     kickPattern: [1,0,0,0, 0,0,1,0, 1,0,0,0, 0,0,1,0],
     snarePattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0],
     hatPattern:   [1,0,1,0, 1,0,0,1, 1,0,1,0, 1,0,0,1],
@@ -193,7 +129,7 @@ export const SONGS = [
     bpm: 130,
     swing: 0.12,
     baseFreq: 130.81, // C3
-    progression: [0, 7, 3, 10, 0, 5, 7, 0], // Cm G Eb Bb | Cm F G Cm
+    progression: [0, 8, 3, 10, 0, 5, 7, 0], // Cm Ab Eb Bb | Cm F G Cm
     kickPattern: [1,0,0,0, 1,0,0,1, 1,0,0,0, 1,0,0,1],
     snarePattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0],
     hatPattern:   [1,0,1,0, 1,1,1,0, 1,0,1,0, 1,1,1,0],
@@ -212,6 +148,19 @@ export const SONGS = [
     hatPattern:   [1,1,0,1, 1,0,1,1, 1,1,0,1, 1,0,1,1],
     leadArp: [0, 12, 16, 12],
     delayTime: 0.21,
+  },
+  {
+    id: 'twilight-echo',
+    name: 'Twilight Echo',
+    bpm: 128,
+    swing: 0.1,
+    baseFreq: 164.81, // E3
+    progression: [0, 8, 3, 10, 0, 5, 10, 0], // Em C G D | Em A D Em
+    kickPattern: [1,0,0,0, 1,0,1,0, 1,0,0,0, 1,0,1,0],
+    snarePattern: [0,0,0,0, 1,0,0,0, 0,0,0,0, 1,0,0,0],
+    hatPattern:   [1,0,1,0, 1,0,0,1, 1,0,1,0, 1,0,0,1],
+    leadArp: [0, 12, 7, 14],
+    delayTime: 0.22,
   },
 ];
 


### PR DESCRIPTION
## Summary
- trim redundant Drive A remixes from `SONGS`
- rework remaining tracks around a shared motif anchored by Drive A and Boss Standoff
- add new "Twilight Echo" theme to round out the album
- enable configurable crossfades between songs in music player for smoother transitions
- display per-bar playback progress in music player and reset it on track changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a63ee90314832299a747938fb48fda