### PR TITLE
Add start menu music source selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,12 @@
     <div class="pill">Headshot bonus</div>
     <div class="pill">Procedural arena</div>
   </div>
+  <div style="display:flex; justify-content:center; margin:12px 0">
+    <select id="musicSelect" class="secondary" style="cursor:pointer; border:0; border-radius:14px; padding:12px 16px; font-weight:900; box-shadow:0 12px 36px #0000002a;">
+      <option value="library">chatGPT 5 music</option>
+      <option value="suno">Suno Remix</option>
+    </select>
+  </div>
   <div style="display:flex; gap:12px; justify-content:center; flex-wrap:wrap">
     <button class="primary" id="play">▶️ Play</button>
     <button class="secondary" id="retry" style="display:none">🔁 Retry</button>


### PR DESCRIPTION
## Summary
- add dropdown on the start menu to choose between chatGPT 5 music or Suno remix tracks
- hook Play/Retry logic to either start procedural music or randomly play a Suno remix
- route the mute button and reset/game-over flow to control Suno audio

## Testing
- `node --check src/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7350d647c83228ef5e8aa27bf8686