### PR TITLE
Add selectable arena shapes

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,15 @@
       <option value="suno">Suno Remix</option>
     </select>
   </div>
+  <div style="display:flex; justify-content:center; margin:12px 0">
+    <select id="arenaShape" class="secondary" style="cursor:pointer; border:0; border-radius:14px; padding:12px 16px; font-weight:900; box-shadow:0 12px 36px #0000002a;">
+      <option value="box">Box Arena</option>
+      <option value="circle">Circle Arena</option>
+      <option value="diamond">Diamond Arena</option>
+      <option value="triangle">Triangle Arena</option>
+      <option value="pi">П Arena</option>
+    </select>
+  </div>
   <div style="display:flex; gap:12px; justify-content:center; flex-wrap:wrap">
     <button class="primary" id="play">▶️ Play</button>
     <button class="secondary" id="retry" style="display:none">🔁 Retry</button>
@@ -107,6 +116,6 @@
     <div id="loadingText" class="tiny" style="margin-top:8px; opacity:0.85">0%</div>
   </div>
 </div>
-<script type="module" src="src/main.js?v=3"></script>
-</body>
-</html>
+  <script type="module" src="src/main.js?v=4"></script>
+  </body>
+  </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';
 import { PointerLockControls } from 'https://unpkg.com/three@0.159.0/examples/jsm/controls/PointerLockControls.js?module';
 import { WeatherSystem } from './weather.js';
-import { createWorld } from './world.js';
+import { createWorld } from './world.js?v=1';
 import { makeSeededRng, makeNamespacedRng, generateSeedString } from './util/rng.js';
 import { EnemyManager } from './enemies.js';
 import { PlayerController } from './player.js';
@@ -32,6 +32,16 @@ if (musicSelect) {
 // ------ Seeded RNG + URL persistence ------
 const url = new URL(window.location.href);
 const params = url.searchParams;
+const shapeSelect = document.getElementById('arenaShape');
+let arenaShape = params.get('shape') || (shapeSelect ? shapeSelect.value : 'box');
+if (shapeSelect) {
+  shapeSelect.value = arenaShape;
+  shapeSelect.addEventListener('change', e => {
+    const u = new URL(window.location.href);
+    u.searchParams.set('shape', e.target.value);
+    window.location.href = `${u.pathname}?${u.searchParams.toString()}`;
+  });
+}
 let seed = params.get('seed');
 if (!seed) {
   seed = generateSeedString(6);
@@ -64,7 +74,7 @@ if (newSeedBtn) {
 }
 
 // ------ World (renderer, scene, camera, lights, sky, materials, arena) ------
-const { renderer, scene, camera, skyMat, hemi, dir, mats, objects } = createWorld(THREE, rng);
+const { renderer, scene, camera, skyMat, hemi, dir, mats, objects } = createWorld(THREE, rng, arenaShape);
 const wantEditor = (new URL(window.location.href)).searchParams.get('editor') === '1';
 const storyParam = (new URL(window.location.href)).searchParams.get('story');
 const storyDisabled = storyParam === '0' || storyParam === 'false';


### PR DESCRIPTION
## Summary
- Add arena shape selector to main menu
- Pass selected shape to world builder
- Support box, circle, diamond, triangle and П-shaped arenas
- Bust cache for main and world scripts so selected shapes load correctly

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7737a66d083229ce972d0dd61e1c3