### PR TITLE
Add gruntling bot asset and integrate into melee enemy

### DIFF
--- a/src/assets/gruntlingbot.js
+++ b/src/assets/gruntlingbot.js
@@ -1,0 +1,14 @@
+import { createGruntBot } from './gruntbot.js';
+
+export function createGruntlingBot({ THREE, mats, cfg = {}, scale = 0.7, palette } = {}) {
+  // Gruntling is a smaller grunt variant with a different color scheme.
+  const glow = cfg.color != null ? cfg.color : 0x3d355d;
+  const colors = Object.assign({
+    armor: 0x9ca3c7,
+    joints: 0x232435,
+    accent: 0x565a7d,
+    visor: 0x111827,
+    glow,
+  }, palette || {});
+  return createGruntBot({ THREE, mats, scale, palette: colors });
+}

--- a/src/enemies/melee.js
+++ b/src/enemies/melee.js
@@ -1,9 +1,11 @@
 import { createBlockBot } from '../assets/blockbot.js';
 import { createGruntBot } from '../assets/gruntbot.js';
+import { createGruntlingBot } from '../assets/gruntlingbot.js';
 // Asset cache: build models once and clone for spawns
 const _enemyAssetCache = {
-	tank: null,
-	grunt: null
+        tank: null,
+        grunt: null,
+        gruntling: null
 };
 
 // --- Melee attack definitions ---
@@ -30,6 +32,32 @@ export class MeleeEnemy {
     if (cfg && cfg.type === 'tank') {
       if (!_enemyAssetCache.tank) _enemyAssetCache.tank = createBlockBot({ THREE, mats, scale: 1.1 });
       const src = _enemyAssetCache.tank;
+      const clone = src.root.clone(true);
+      // Remap anim refs from original asset graph to this clone so animations affect the visible mesh
+      const remapRefs = (srcRoot, cloneRoot, refs) => {
+        const out = {};
+        const getPath = (node) => {
+          const path = [];
+          let cur = node;
+          while (cur && cur !== srcRoot) {
+            const parent = cur.parent; if (!parent) return null;
+            const idx = parent.children.indexOf(cur); if (idx < 0) return null;
+            path.push(idx); cur = parent;
+          }
+          return path.reverse();
+        };
+        const follow = (root, path) => {
+          let cur = root; for (const idx of (path||[])) { if (!cur || !cur.children || idx >= cur.children.length) return null;
+cur = cur.children[idx]; }
+          return cur;
+        };
+        for (const k of Object.keys(refs||{})) { const p = getPath(refs[k]); out[k] = p ? follow(cloneRoot, p) : null; }
+        return out;
+      };
+      body = clone; head = clone.userData?.head || src.head; this._animRefs = remapRefs(src.root, clone, src.refs || {});
+    } else if (cfg && cfg.type === 'gruntling') {
+      if (!_enemyAssetCache.gruntling) _enemyAssetCache.gruntling = createGruntlingBot({ THREE, mats, cfg, scale: 0.7 });
+      const src = _enemyAssetCache.gruntling;
       const clone = src.root.clone(true);
       // Remap anim refs from original asset graph to this clone so animations affect the visible mesh
       const remapRefs = (srcRoot, cloneRoot, refs) => {


### PR DESCRIPTION
## Summary
- Implement `createGruntlingBot` asset with reduced scale and customizable palette
- Hook gruntling asset into melee enemy spawning and cache

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a782a205e48322885e7b864c4ef71d