### PR TITLE
Update Hydraclone wave tracking

### DIFF
--- a/src/bosses/hydraclone.js
+++ b/src/bosses/hydraclone.js
@@ -132,7 +132,12 @@ export class Hydraclone {
   // --- Manager/scene registration helper (used by global queue spawns) ---
   static registerInstance(inst, ctx) {
     if (inst.enemyManager && typeof inst.enemyManager.registerExternalEnemy === 'function') {
+      // Ensure waveStartingAlive is a number before tracking additional spawns
+      if (typeof inst.enemyManager.waveStartingAlive !== 'number') {
+        inst.enemyManager.waveStartingAlive = inst.enemyManager.alive || 0;
+      }
       inst.enemyManager.registerExternalEnemy(inst, { countsTowardAlive: true });
+      inst.enemyManager.waveStartingAlive++;
       return inst;
     }
     // Fallback if no manager helper available


### PR DESCRIPTION
## Summary
- keep `waveStartingAlive` in sync by incrementing after each Hydraclone spawn
- initialize `waveStartingAlive` before the first Hydraclone registration

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a78b8c293c832296d04e9a2dc1fb15