### PR TITLE
feat: add beam saber swing animation

### DIFF
--- a/src/weapons/beamsaber.js
+++ b/src/weapons/beamsaber.js
@@ -24,6 +24,7 @@ export class BeamSaber extends Weapon {
     const hits = candidates.length ? raycaster.intersectObjects(candidates, true) : [];
     const handled = new Set();
 
+    ctx.weaponView?.startSlash?.();
     if (S?.saberSwing) S.saberSwing();
     effects?.spawnSaberSlash?.(origin, end);
 


### PR DESCRIPTION
## Summary
- add slash animation state to weapon view and expose `startSlash`
- trigger saber swing animation on beam saber firing

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a79a00ca7c8322b503ec5d05590d70