### PR TITLE
Request fullscreen on mobile start

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <div class="pill" id="mute">🔊</div>
   </div>
   <div class="row" style="justify-content:flex-end">
-    <div class="pill tiny">WASD move • Mouse aim • Click shoot • R reload • Shift sprint • Ctrl crouch • Space jump • P pause</div>
+    <div class="pill tiny" id="desktopHelp">WASD move • Mouse aim • Click shoot • R reload • Shift sprint • Ctrl crouch • Space jump • P pause</div>
   </div>
   </div>
   <div id="crosshair">
@@ -95,9 +95,26 @@
     <button class="secondary" id="qHigh" title="aa=on, shadows=on">High</button>
     <button class="secondary" id="qUltra" title="aa=on, shadows=on (max)" >Ultra</button>
   </div>
-  <div class="tiny" style="margin-top:8px">Click Play, then click to lock the mouse.
-  </div>
-</div></div>
-<script type="module" src="src/main.js"></script>
-</body>
-</html>
+    <div class="tiny" style="margin-top:8px" id="startTip">Click Play, then click to lock the mouse.
+    </div>
+  </div></div>
+  <script>
+    window.IS_MOBILE = window.matchMedia('(pointer:coarse)').matches;
+    if (window.IS_MOBILE) {
+      const m = document.createElement('div');
+      m.id = 'mobileControls';
+      m.innerHTML = `
+        <div id="joystick" class="joy"><div class="base"></div><div class="knob"></div></div>
+        <div id="actionButtons">
+          <button id="btnFire">🔥</button>
+          <button id="btnJump">⤴️</button>
+          <button id="btnReload">🔄</button>
+        </div>`;
+      document.body.appendChild(m);
+      const help = document.getElementById('desktopHelp');
+      if (help) help.style.display = 'none';
+    }
+  </script>
+  <script type="module" src="src/main.js"></script>
+  </body>
+  </html>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -73,3 +73,13 @@ button{ cursor:pointer; border:0; border-radius:14px; padding:12px 16px; font-we
 @keyframes toastOut{ to{ opacity:0; transform:translateY(-6px);} }
 
 
+/* Mobile controls */
+@media (pointer:coarse){
+  #hud{ padding-bottom:120px; }
+  #mobileControls{ position:fixed; inset:0; pointer-events:none; }
+  #mobileControls #joystick{ position:absolute; left:20px; bottom:20px; width:100px; height:100px; pointer-events:auto; }
+  #mobileControls #joystick .base{ position:absolute; inset:0; background:#ffffff55; border:2px solid #00000033; border-radius:50%; }
+  #mobileControls #joystick .knob{ position:absolute; left:50%; top:50%; width:40px; height:40px; margin-left:-20px; margin-top:-20px; background:var(--panel); border:2px solid #00000055; border-radius:50%; }
+  #mobileControls #actionButtons{ position:absolute; right:20px; bottom:20px; display:flex; flex-direction:column; gap:12px; pointer-events:auto; }
+  #mobileControls #actionButtons button{ width:60px; height:60px; border-radius:50%; background:var(--panel); border:2px solid #00000018; box-shadow:0 10px 30px #00000022; font-size:24px; font-weight:800; }
+}


### PR DESCRIPTION
## Summary
- Request fullscreen when the game is started on mobile
- Share start logic between Play and Retry buttons
- Inject mobile-specific joystick and action buttons while hiding desktop-only HUD hints
- Track the finger controlling camera look to avoid multi-touch conflicts
- Stop action button taps from triggering look mode on mobile

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a79e205f4883229dbb6e769b2c0228