### PR TITLE
Improve mobile UI layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,19 @@
       document.body.appendChild(m);
       const help = document.getElementById('desktopHelp');
       if (help) help.style.display = 'none';
+      const hud = document.getElementById('hud');
+      if (hud) {
+        const row = document.createElement('div');
+        row.className = 'row';
+        row.style.justifyContent = 'flex-end';
+        row.innerHTML = '<div class="pill tiny" id="mobileHelp">Move: joystick • Shoot: 🔥 • Jump: ⤴️</div>';
+        hud.appendChild(row);
+        const hideHelp = () => document.getElementById('mobileHelp')?.remove();
+        setTimeout(hideHelp, 5000);
+        ['joystick','btnFire','btnJump','btnReload'].forEach(id=>{
+          document.getElementById(id)?.addEventListener('touchstart', hideHelp, {once:true});
+        });
+      }
     }
   </script>
   <script type="module" src="src/main.js"></script>

--- a/src/player.js
+++ b/src/player.js
@@ -86,13 +86,16 @@ export class PlayerController {
         if (dx > threshold) this.keys.add('KeyD');
       };
       if (joyEl){
-        let active = false;
+        let active = false, joyId = null;
         joyEl.addEventListener('touchstart', e=>{
+          const t = e.changedTouches[0];
+          joyId = t.identifier;
           active = true; e.preventDefault();
         });
         joyEl.addEventListener('touchmove', e=>{
           if(!active) return; e.preventDefault();
-          const t = e.touches[0];
+          const t = Array.from(e.touches).find(tt=>tt.identifier===joyId);
+          if(!t) return;
           const rect = joyEl.getBoundingClientRect();
           const r = rect.width/2;
           const x = t.clientX - (rect.left + r);
@@ -105,12 +108,16 @@ export class PlayerController {
           updateFromVector(dx, dy);
         }, {passive:false});
         const reset = ()=>{
-          active = false;
+          active = false; joyId = null;
           if (knob) knob.style.transform = 'translate(0,0)';
           updateFromVector(0,0);
         };
-        joyEl.addEventListener('touchend', reset);
-        joyEl.addEventListener('touchcancel', reset);
+        joyEl.addEventListener('touchend', e=>{
+          if(Array.from(e.changedTouches).some(t=>t.identifier===joyId)) reset();
+        });
+        joyEl.addEventListener('touchcancel', e=>{
+          if(Array.from(e.changedTouches).some(t=>t.identifier===joyId)) reset();
+        });
       }
         // Look controls on right side
         let lookId = null, lx=0, ly=0;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -75,7 +75,9 @@ button{ cursor:pointer; border:0; border-radius:14px; padding:12px 16px; font-we
 
 /* Mobile controls */
 @media (pointer:coarse){
-  #hud{ padding-bottom:120px; }
+  #hud{ padding:6px 6px 120px; }
+  #hud .row{ flex-wrap:wrap; gap:6px; }
+  #hud .pill{ padding:6px 8px; font-size:14px; }
   #mobileControls{ position:fixed; inset:0; pointer-events:none; }
   #mobileControls #joystick{ position:absolute; left:20px; bottom:20px; width:100px; height:100px; pointer-events:auto; }
   #mobileControls #joystick .base{ position:absolute; inset:0; background:#ffffff55; border:2px solid #00000033; border-radius:50%; }


### PR DESCRIPTION
## Summary
- Ensure HUD wraps and scales for small screens
- Add on-screen guidance for mobile controls
- Hide mobile controls hint after initial use
- Fix joystick touch tracking to avoid unintended movement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8259b30a4832281040595d66beb7c