### PR TITLE
Expand npm test suite for RNG, music, and game mechanics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "quarantine-of-joy-game",
+  "version": "1.0.0",
+  "description": "Quarantine of Joy web game",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/test/music.test.js
+++ b/test/music.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Music } from '../src/music.js';
+
+// Provide a no-op audio context to satisfy constructor without accessing Web Audio APIs
+const dummyCtx = {};
+
+function makeMusic(){
+  return new Music({ audioContextProvider: () => dummyCtx });
+}
+
+test('noteToFreq converts semitone offset to frequency', () => {
+  const music = makeMusic();
+  const freq = music.noteToFreq(440, 12); // one octave up
+  assert.equal(Math.round(freq), 880);
+});
+
+test('makeMinorChord returns minor triad', () => {
+  const music = makeMusic();
+  assert.deepStrictEqual(music.makeMinorChord(5), [5, 8, 12]);
+});

--- a/test/musicLibrary.test.js
+++ b/test/musicLibrary.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SONGS } from '../src/musicLibrary.js';
+
+const patternProps = ['kickPattern','snarePattern','hatPattern','clapPattern','ridePattern','stabPattern'];
+
+test('songs have expected structure', () => {
+  for (const song of SONGS) {
+    assert.ok(song.id && song.name, 'song must have id and name');
+    assert.equal(song.progression.length, 8, 'progression has 8 steps');
+    patternProps.forEach(prop => {
+      assert.equal(song[prop].length, 16, `${prop} length`);
+    });
+    assert.equal(song.leadArp.length, 4, 'leadArp has 4 notes');
+  }
+});
+

--- a/test/rng.test.js
+++ b/test/rng.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { makeSeededRng, makeNamespacedRng, generateSeedString } from '../src/util/rng.js';
+
+test('makeSeededRng returns deterministic sequence', () => {
+  const rng1 = makeSeededRng('seed');
+  const rng2 = makeSeededRng('seed');
+  const seq1 = [rng1(), rng1(), rng1()];
+  const seq2 = [rng2(), rng2(), rng2()];
+  assert.deepStrictEqual(seq1, seq2);
+});
+
+test('rand.int and rand.range produce numbers in range', () => {
+  const rng = makeSeededRng('seed');
+  for (let i = 0; i < 10; i++) {
+    const intVal = rng.int(1, 5);
+    assert.ok(intVal >= 1 && intVal <= 5);
+    const rangeVal = rng.range(10, 20);
+    assert.ok(rangeVal >= 10 && rangeVal < 20);
+  }
+});
+
+test('makeNamespacedRng combines seed and namespace', () => {
+  const a = makeNamespacedRng('base', 'ns');
+  const b = makeSeededRng('base:ns');
+  assert.equal(a(), b());
+});
+
+test('generateSeedString returns expected alphabet and length', () => {
+  const str = generateSeedString(12);
+  assert.equal(str.length, 12);
+  assert.match(str, /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{12}$/);
+});

--- a/test/weapon.test.js
+++ b/test/weapon.test.js
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Weapon } from '../src/weapons/base.js';
+
+test('tryFire reduces ammo and respects fire delay', () => {
+  const w = new Weapon({ mode: 'semi', fireDelayMs: 100, magSize: 2, reserve: 0 });
+  const origNow = performance.now;
+  let now = 0;
+  performance.now = () => now;
+  try {
+    assert.equal(w.getAmmo(), 2);
+    assert.ok(w.tryFire({}));
+    assert.equal(w.getAmmo(), 1);
+
+    now = 50;
+    assert.equal(w.tryFire({}), false, 'cannot fire during cooldown');
+    now = 100;
+    assert.ok(w.tryFire({}), 'fires after cooldown');
+
+    assert.equal(w.getAmmo(), 0);
+    now = 200;
+    assert.equal(w.tryFire({}), false, 'cannot fire with empty mag');
+  } finally {
+    performance.now = origNow;
+  }
+});
+
+test('reload fills magazine from reserve', () => {
+  const w = new Weapon({ mode: 'semi', fireDelayMs: 0, magSize: 3, reserve: 5 });
+  w.ammoInMag = 1; // simulate two shots fired
+  let played = false;
+  const reloaded = w.reload(() => { played = true; });
+  assert.ok(reloaded);
+  assert.equal(w.getAmmo(), 3);
+  assert.equal(w.getReserve(), 3);
+  assert.ok(played, 'sound callback invoked');
+
+  assert.equal(w.reload(), false, 'cannot reload when mag full');
+  w.ammoInMag = 0;
+  w.reserveAmmo = 0;
+  assert.equal(w.reload(), false, 'cannot reload without reserve');
+});
+
+test('addReserve increases reserve and reset restores counts', () => {
+  const w = new Weapon({ mode: 'semi', fireDelayMs: 0, magSize: 5, reserve: 10 });
+  w.addReserve(5);
+  assert.equal(w.getReserve(), 15);
+  w.addReserve(-3);
+  assert.equal(w.getReserve(), 15, 'negative amounts ignored');
+
+  w.ammoInMag = 2;
+  w.reserveAmmo = 7;
+  w.reset();
+  assert.equal(w.getAmmo(), 5);
+  assert.equal(w.getReserve(), 10);
+});
+


### PR DESCRIPTION
## Summary
- configure package.json for ESM and npm test via `node --test`
- add deterministic RNG tests, music helper coverage, and song data validation
- add weapon base class tests for firing cadence, reload logic, and ammo resets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7a10a6a7c8322a521359bcee87418