### PR TITLE
Add toggleable sprint button for mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Faction/style: Bureau of Blandness Compliance unit. Monochrome, municipal-minima
 - **WASD** to move, **Space** to jump
 - **Shift** to sprint, **Ctrl** to crouch
 - **Left Mouse** to fire your weapon
+- On mobile: use the on‑screen joystick to move and buttons to Shoot 🔥, Jump ⤴️, Reload 🔄
+- Tap 🏃 to lock or unlock sprint on mobile
 
 ## Running locally
 

--- a/docs/gamedesign/mechanics.md
+++ b/docs/gamedesign/mechanics.md
@@ -5,7 +5,7 @@
 - Aim: mouse
 - Shoot: left click
 - Reload: `R`
-- Sprint: `Shift`
+- Sprint: `Shift` (tap 🏃 on mobile to lock or unlock sprint)
 - Crouch: `Ctrl`
 - Jump: `Space`
 - Pause: `P`
@@ -89,6 +89,7 @@ Small, frequent bonuses awarded at combo tier‑ups and periodic milestones to k
 
 ### Stamina
 - Sprint and jump consume stamina; stamina regenerates when not sprinting/jumping.
+- On mobile, sprinting is toggled via an on-screen 🏃 button that locks sprint until tapped again.
 - Baseline: 100 stamina. Sprint cost ~12/s; Jump cost ~15; Regen 18/s after 0.5s delay.
 - Low‑stamina penalties: reduced sprint speed; cannot jump below 15 stamina.
 

--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@
           <button id="btnFire">🔥</button>
           <button id="btnJump">⤴️</button>
           <button id="btnReload">🔄</button>
+          <button id="btnSprint">🏃</button>
         </div>`;
       document.body.appendChild(m);
       const help = document.getElementById('desktopHelp');
@@ -118,12 +119,12 @@
         const row = document.createElement('div');
         row.className = 'row';
         row.style.justifyContent = 'flex-end';
-        row.innerHTML = '<div class="pill tiny" id="mobileHelp">Move: joystick • Shoot: 🔥 • Jump: ⤴️</div>';
+        row.innerHTML = '<div class="pill tiny" id="mobileHelp">Move: joystick • Shoot: 🔥 • Jump: ⤴️ • Sprint: 🏃</div>';
         hud.appendChild(row);
         const hideHelp = () => document.getElementById('mobileHelp')?.remove();
         setTimeout(hideHelp, 5000);
-        ['joystick','btnFire','btnJump','btnReload'].forEach(id=>{
-          document.getElementById(id)?.addEventListener('touchstart', hideHelp, {once:true});
+        ['joystick','btnFire','btnJump','btnReload','btnSprint'].forEach(id=>{
+          document.getElementById(id)?.addEventListener('pointerdown', hideHelp, {once:true});
         });
       }
     }

--- a/src/main.js
+++ b/src/main.js
@@ -461,6 +461,8 @@ if (!isMobile){
   const fireBtn = document.getElementById('btnFire');
   const reloadBtn = document.getElementById('btnReload');
   const jumpBtn = document.getElementById('btnJump');
+  const sprintBtn = document.getElementById('btnSprint');
+  let sprinting = false;
   if (fireBtn){
     fireBtn.addEventListener('touchstart', e=>{ e.preventDefault(); e.stopPropagation(); weaponSystem.triggerDown(); }, {passive:false});
     const end = ()=> weaponSystem.triggerUp();
@@ -474,6 +476,19 @@ if (!isMobile){
   if (jumpBtn){
     jumpBtn.addEventListener('touchstart', e=>{ e.preventDefault(); e.stopPropagation(); }, {passive:false});
     jumpBtn.addEventListener('touchend', ()=>{ player.jump(); });
+  }
+  if (sprintBtn){
+    sprintBtn.addEventListener('touchstart', e=>{ e.preventDefault(); e.stopPropagation(); }, {passive:false});
+    sprintBtn.addEventListener('touchend', e=>{
+      e.preventDefault(); e.stopPropagation();
+      sprinting = !sprinting;
+      if (sprinting){
+        player.keys.add('ShiftLeft');
+      } else {
+        player.keys.delete('ShiftLeft');
+      }
+      sprintBtn.classList.toggle('active', sprinting);
+    });
   }
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -83,5 +83,9 @@ button{ cursor:pointer; border:0; border-radius:14px; padding:12px 16px; font-we
   #mobileControls #joystick .base{ position:absolute; inset:0; background:#ffffff55; border:2px solid #00000033; border-radius:50%; }
   #mobileControls #joystick .knob{ position:absolute; left:50%; top:50%; width:40px; height:40px; margin-left:-20px; margin-top:-20px; background:var(--panel); border:2px solid #00000055; border-radius:50%; }
   #mobileControls #actionButtons{ position:absolute; right:20px; bottom:20px; display:flex; flex-direction:column; gap:12px; pointer-events:auto; }
-  #mobileControls #actionButtons button{ width:60px; height:60px; border-radius:50%; background:var(--panel); border:2px solid #00000018; box-shadow:0 10px 30px #00000022; font-size:24px; font-weight:800; }
+    #mobileControls #actionButtons button{ width:60px; height:60px; border-radius:50%; background:var(--panel); border:2px solid #00000018; box-shadow:0 10px 30px #00000022; font-size:24px; font-weight:800; }
+    #mobileControls #actionButtons button.active{
+      background:#94a3b8;
+      opacity:0.8;
+    }
 }


### PR DESCRIPTION
## Summary
- add 🏃 button to mobile UI to toggle sprint
- darken sprint button and sync its active state with sprint lock
- document mobile sprint control in README and mechanics design
- hide mobile help after touching joystick or any action button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8298308a4832294a2840ab5f9e9ab