### PR TITLE
Ensure start menu fits on mobile landscape

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -12,7 +12,12 @@ body{margin:0; overflow:hidden; font-family: Inter, system-ui, -apple-system, Se
 .pill.tiny{ font-weight:700; }
 .mini{ margin-left:6px; padding:4px 8px; border-radius:10px; font-weight:800; cursor:pointer; border:1px solid #00000022; background:#ffffffb0; }
 #center{ position:fixed; inset:0; display:grid; place-items:center; }
-#panel{ pointer-events:auto; width:min(92%,560px); text-align:center; background:var(--panel); border:3px solid #00000018; border-radius:22px; padding:22px; box-shadow:0 25px 80px #00000055; }
+#panel{ pointer-events:auto; width:min(92%,560px); text-align:center; background:var(--panel); border:3px solid #00000018; border-radius:22px; padding:22px; box-shadow:0 25px 80px #00000055; max-height:100vh; overflow:auto; box-sizing:border-box; }
+
+@media (max-height:500px){
+  #center{ align-items:flex-start; overflow-y:auto; }
+  #panel{ margin-top:20px; }
+}
 h1{ margin:6px 0 4px; font-size: clamp(26px,5vw,44px);} h1 span{ color:#22c55e }
 button{ cursor:pointer; border:0; border-radius:14px; padding:12px 16px; font-weight:900; box-shadow:0 12px 36px #0000002a; }
 .primary{ background:linear-gradient(180deg,#22c55e,#86efac); color:#062e12 }


### PR DESCRIPTION
## Summary
- Allow start panel to scroll on short screens and top-align when height is limited

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a838baa1888322a449cb7bf3f0891c