### PR TITLE
Refine mobile start screen layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,14 +87,12 @@
     <div class="pill">Headshot bonus</div>
     <div class="pill">Procedural arena</div>
   </div>
-  <div style="display:flex; justify-content:center; margin:12px 0">
-    <select id="musicSelect" class="secondary" style="cursor:pointer; border:0; border-radius:14px; padding:12px 16px; font-weight:900; box-shadow:0 12px 36px #0000002a;">
+  <div style="display:flex; justify-content:center; gap:8px; margin:12px 0; flex-wrap:wrap">
+    <select id="musicSelect" class="secondary startSelect" style="cursor:pointer; border:0; border-radius:14px; padding:12px 16px; font-weight:900; box-shadow:0 12px 36px #0000002a;">
       <option value="library">chatGPT 5 music</option>
       <option value="suno">Suno Remix</option>
     </select>
-  </div>
-  <div style="display:flex; justify-content:center; margin:12px 0">
-    <select id="arenaShape" class="secondary" style="cursor:pointer; border:0; border-radius:14px; padding:12px 16px; font-weight:900; box-shadow:0 12px 36px #0000002a;">
+    <select id="arenaShape" class="secondary startSelect" style="cursor:pointer; border:0; border-radius:14px; padding:12px 16px; font-weight:900; box-shadow:0 12px 36px #0000002a;">
       <option value="box">Box Arena</option>
       <option value="circle">Circle Arena</option>
       <option value="diamond">Diamond Arena</option>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -91,6 +91,8 @@ button{ cursor:pointer; border:0; border-radius:14px; padding:12px 16px; font-we
   #hud{ padding:6px 6px 120px; }
   #hud .row{ flex-wrap:wrap; gap:6px; }
   #hud .pill{ padding:6px 8px; font-size:14px; }
+  #panel .pill{ padding:4px 6px; font-size:12px; }
+  #panel .startSelect{ flex:1; min-width:150px; }
   #mobileControls{ position:fixed; inset:0; pointer-events:none; }
   #mobileControls #joystick{ position:absolute; left:20px; bottom:20px; width:100px; height:100px; pointer-events:auto; }
   #mobileControls #joystick .base{ position:absolute; inset:0; background:#ffffff55; border:2px solid #00000033; border-radius:50%; }


### PR DESCRIPTION
## Summary
- shrink start-screen tag pills on mobile for better fit
- place music and arena selectors on the same row

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a83b4261c48322a42d16eb415c27a5