### PR TITLE
Ignore extruded arena wall in collider bounds

### DIFF
--- a/src/enemies/manager.js
+++ b/src/enemies/manager.js
@@ -25,7 +25,9 @@ export class EnemyManager {
     this.onWave = null;
     this.onRemaining = null;
 
-    this.objectBBs = this.objects.map(o => new this.THREE.Box3().setFromObject(o));
+    this.objectBBs = this.objects
+      .filter(o => o.geometry?.type !== 'ExtrudeGeometry')
+      .map(o => new this.THREE.Box3().setFromObject(o));
     this.raycaster = new this.THREE.Raycaster();
     try { this.raycaster.firstHitOnly = true; } catch(_) {}
     this.up = new this.THREE.Vector3(0,1,0);
@@ -70,7 +72,9 @@ export class EnemyManager {
   // Rebuild collidable AABBs after the shared objects list changes (e.g., obstacles destroyed)
   refreshColliders(objects = this.objects) {
     this.objects = objects;
-    this.objectBBs = this.objects.map(o => new this.THREE.Box3().setFromObject(o));
+    this.objectBBs = this.objects
+      .filter(o => o.geometry?.type !== 'ExtrudeGeometry')
+      .map(o => new this.THREE.Box3().setFromObject(o));
   }
 
   _initBulletPools() {

--- a/src/player.js
+++ b/src/player.js
@@ -53,8 +53,10 @@ export class PlayerController {
     this.recoilImpulse = 10.0;      // velocity gain per input rad
     this.recoilMaxPitch = 0.35;     // safety cap (~20°)
 
-    // Collision helpers
-    this.objectBBs = this.objects.map(o => new THREE.Box3().setFromObject(o));
+    // Collision helpers (skip extruded walls)
+    this.objectBBs = this.objects
+      .filter(o => o.geometry?.type !== 'ExtrudeGeometry')
+      .map(o => new THREE.Box3().setFromObject(o));
     this.colliderHalf = new THREE.Vector3(0.35, 0.9, 0.35); // approx capsule half extents
     this.fullHeight = this.colliderHalf.y * 2; // ~1.8m
     this._groundRaycaster = new THREE.Raycaster();
@@ -184,7 +186,9 @@ export class PlayerController {
   refreshColliders(objects){
     const THREE = this.THREE;
     this.objects = objects;
-    this.objectBBs = this.objects.map(o => new THREE.Box3().setFromObject(o));
+    this.objectBBs = this.objects
+      .filter(o => o.geometry?.type !== 'ExtrudeGeometry')
+      .map(o => new THREE.Box3().setFromObject(o));
   }
 
   resetPosition(x=0, y=1.7, z=8){


### PR DESCRIPTION
## Summary
- skip ExtrudeGeometry meshes when building player collision boxes
- apply same filtering for enemy manager so enemies move correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8402ff3d08322a360901f3159b2b1