### PR TITLE
Fix collision filtering for extruded geometry

### DIFF
--- a/src/enemies/manager.js
+++ b/src/enemies/manager.js
@@ -9,6 +9,14 @@ import { SwarmWarden } from './warden.js';
 import { BossManager } from '../bosses/manager.js';
 import { Hydraclone } from '../bosses/hydraclone.js';
 
+function containsExtrudeGeometry(obj){
+  if (obj.geometry?.isExtrudeGeometry) return true;
+  for (const child of obj.children || []){
+    if (containsExtrudeGeometry(child)) return true;
+  }
+  return false;
+}
+
 export class EnemyManager {
   constructor(THREE, scene, mats, objects = [], getPlayer = null, arenaRadius = Infinity) {
     this.THREE = THREE;
@@ -27,7 +35,7 @@ export class EnemyManager {
     this.onRemaining = null;
 
     this.objectBBs = this.objects
-      .filter(o => !o.geometry?.isExtrudeGeometry)
+      .filter(o => !containsExtrudeGeometry(o))
       .map(o => new this.THREE.Box3().setFromObject(o));
     this.raycaster = new this.THREE.Raycaster();
     try { this.raycaster.firstHitOnly = true; } catch(_) {}
@@ -74,7 +82,7 @@ export class EnemyManager {
   refreshColliders(objects = this.objects) {
     this.objects = objects;
     this.objectBBs = this.objects
-      .filter(o => !o.geometry?.isExtrudeGeometry)
+      .filter(o => !containsExtrudeGeometry(o))
       .map(o => new this.THREE.Box3().setFromObject(o));
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -1,5 +1,13 @@
 import { PointerLockControls } from 'https://unpkg.com/three@0.159.0/examples/jsm/controls/PointerLockControls.js?module';
 
+function containsExtrudeGeometry(obj){
+  if (obj.geometry?.isExtrudeGeometry) return true;
+  for (const child of obj.children || []){
+    if (containsExtrudeGeometry(child)) return true;
+  }
+  return false;
+}
+
 export class PlayerController {
   constructor(THREE, camera, domElement, collidableObjects, arenaRadius = Infinity){
     this.THREE = THREE;
@@ -55,7 +63,7 @@ export class PlayerController {
 
     // Collision helpers (skip extruded walls)
     this.objectBBs = this.objects
-      .filter(o => !o.geometry?.isExtrudeGeometry)
+      .filter(o => !containsExtrudeGeometry(o))
       .map(o => new THREE.Box3().setFromObject(o));
     this.colliderHalf = new THREE.Vector3(0.35, 0.9, 0.35); // approx capsule half extents
     this.fullHeight = this.colliderHalf.y * 2; // ~1.8m
@@ -187,7 +195,7 @@ export class PlayerController {
     const THREE = this.THREE;
     this.objects = objects;
     this.objectBBs = this.objects
-      .filter(o => !o.geometry?.isExtrudeGeometry)
+      .filter(o => !containsExtrudeGeometry(o))
       .map(o => new THREE.Box3().setFromObject(o));
   }
 


### PR DESCRIPTION
## Summary
- add containsExtrudeGeometry helper to recursively detect ExtrudeGeometry
- ignore extruded meshes when building player and enemy colliders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a848f55e9483228dc045714d7f69d2