### PR TITLE
Round down player health display

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -330,7 +330,7 @@ function updateHUD(){
     const iconMap = { Rifle:'assets/icons/weapon-rifle.svg', SMG:'assets/icons/weapon-smg.svg', Shotgun:'assets/icons/weapon-shotgun.svg', DMR:'assets/icons/weapon-dmr.svg', Pistol:'assets/icons/weapon-pistol.svg', BeamSaber:'assets/icons/weapon-beamsaber.svg' };
     weaponIconEl.src = iconMap[w?.name] || iconMap.Rifle;
   }
-  hpEl.textContent=hp; ammoEl.textContent=ammoVal; magEl.textContent=reserveVal; scoreEl.textContent=score; if (bestEl) bestEl.textContent = best; if(waveEl) waveEl.textContent = enemyManager.wave;
+  hpEl.textContent = Math.floor(hp); ammoEl.textContent=ammoVal; magEl.textContent=reserveVal; scoreEl.textContent=score; if (bestEl) bestEl.textContent = best; if(waveEl) waveEl.textContent = enemyManager.wave;
   updateHUDComboAndBoss();
 }
 


### PR DESCRIPTION
## Summary
- ensure player health is displayed as an integer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a853c6fcbc8322b6623300494f0785