### PR TITLE
docs: document full weapon lineup

### DIFF
--- a/docs/gamedesign/weapons.md
+++ b/docs/gamedesign/weapons.md
@@ -1,35 +1,54 @@
-# Weapons Progression Plan
+# Weapons Progression
 
 This document refines mechanics.md slots and offers into concrete rules, UI, and implementation steps.
 
 ## Loadout & Slots
-- Slots: Primary (key 1) and Sidearm (key 5). Start kit: Rifle + Pistol.
+- Slots: Primary (key 1) and Sidearm (key 2). Start kit: Pistol only; SMG granted automatically at Wave 2.
 - Sidearm is permanent during a run (cannot be dropped). Primary can be swapped.
 
 ## Unlocks (persistent)
 - Unlock table (saved locally):
-  - SMG: reach Wave ≥3 once
-  - Shotgun: reach Wave ≥4 once
-  - DMR: reach Wave ≥6 once
+  - SMG: reach Wave ≥2 once
+  - Shotgun: reach Wave ≥3 once
+  - BeamSaber: reach Wave ≥3 once
+  - Minigun: reach Wave ≥4 once
+  - Rifle: reach Wave ≥6 once
+  - DMR: reach Wave ≥11 once
 
 ## Armory Offers (per run)
-- Timing: end of even waves starting at Wave 2. If you swapped on the previous offer, the next offer is skipped (no back‑to‑back swaps).
+- Early script:
+  - Wave 2: auto-equip SMG as first Primary.
+  - Wave 3: offer Shotgun vs SMG.
+  - Wave 4: offer BeamSaber.
+  - Wave 6: offer Rifle vs SMG.
+  - Wave 8: offer Minigun.
+  - Wave 11: offer Rifle vs DMR.
+  - Wave 12: offer DMR vs BeamSaber.
+- Normal cadence: end of even waves ≥6 afterward (respect swap cooldown).
+- Swap cooldown: accepting an offer skips the next one (no back‑to‑back swaps). Declining does not.
 - Flow: present 2 random weapons from unlocked pool excluding current Primary. Choose 1 to replace Primary, or Decline.
 - Decline bonus: +20% reserve to current Primary (clamped by soft cap per weapon).
 - Reserve conversion on swap: newReserve = floor(0.5 × oldReserve) + defaultReserve(newWeapon). Magazine refills to full on swap.
 
+## Sidearm Offer
+- Once per run at Wave ≥15, present sidearm choices excluding the current sidearm (Pistol, Grenade, BeamSaber).
+- Sidearm swaps ignore the Armory swap cooldown and grant no decline bonus.
+
 ## Weapon Crates (drops)
-- Starting Wave 3: rare drop (≈5% base, pity +1%/miss, cap 1 per wave). Opening crate spawns a single weapon choice to replace Primary, same reserve conversion rule.
+- Starting Wave 3: rare drop (≈5% base, pity +1%/miss, cap 1 per wave).
+  Opening crate spawns a single weapon choice to replace Primary, same reserve conversion rule.
+- Crate swaps ignore the Armory swap cooldown; only accepting an Armory offer delays the next one.
 
 ## Economy Rules
 - Ammo pickups always add to the equipped weapon's reserve.
 - Reload draws only from that reserve; never negative, clamp to mag size.
-- Soft reserve caps by weapon (for future tuning): Rifle 300, SMG 360, Shotgun 60, DMR 120, Pistol 120.
+- Soft reserve caps by weapon (for future tuning): Rifle 300, SMG 360, Shotgun 60, DMR 120, Minigun 600, Pistol 120, Grenade 24.
 
 ## Boss Rewards
-- On boss defeat: choose one
-  - Refine Primary: one of two small, weapon‑specific buffs (e.g., +10% mag, −8% bloom, +10% falloff).
+- On boss defeat (every 5th wave): choose one
+  - Refine Primary: one of two small, weapon‑specific buffs (e.g., +5% magazine, −5% bloom, +7% falloff range).
   - New Primary: swap to a random unlocked Primary with 1.25× default reserve.
+- Guardrails: no repeat refine choices consecutively; refine bonuses cap at +10% magazine / −10% bloom / +15% falloff in a run.
 
 ## UI
 - HUD shows current Primary name and ammo; offer banner: "Armory Offer (F) – Choose 1 of 2".
@@ -43,53 +62,9 @@ This document refines mechanics.md slots and offers into concrete rules, UI, and
 5) Hook boss rewards: on boss death, invoke OfferSystem with special rules.
 
 ## Acceptance
-- Player starts with Rifle + Pistol; only Primary changes.
-- Offers appear per schedule; no back‑to‑back swaps after accepting one.
+- Player starts with only a Pistol; SMG arrives at Wave 2.
+- Primary changes follow offer schedule; sidearm can change once via sidearm offer.
 - Reserve conversion works; decline yields +20% reserve (clamped).
 - Ammo economy respects per‑weapon reserves; no negatives or overfills.
 
-# Weapons Progression
-
-## Slots and Starting Kit
-- Two slots: Primary (slot 1) and Sidearm (slot 2).
-- Start each run with Rifle (Primary, key 1) + Pistol (Sidearm, key 2).
-- Sidearm is permanent (cannot be dropped); Primary can be swapped.
-
-## Unlocks (Persistent)
-- Reach Wave 3 once → unlock Shotgun.
-- Reach Wave 5 once → unlock SMG.
-- Reach Wave 10 once → unlock DMR.
-- Unlocks saved locally; future runs roll unlocked weapons in offers/drops.
-
-## Per‑Run Acquisition
-- Armory Offer after waves 2, 4, 6, 8, …
-  - Present 2 random weapons from unlocked pool (excluding current Primary archetype).
-  - Choose 1 to replace Primary; Decline → +ammo top‑up for current Primary (default +20% reserve, clamped by soft‑cap).
-  - Guardrail: if you swapped on the previous offer, skip the next scheduled offer (no back‑to‑back swaps).
-- Rare Weapon Crate (enemy drop)
-  - Starts at Wave 3. Base drop ~5% per wave; pity +1%/miss; cap 1 crate per wave.
-  - Opening spawns 1 weapon from unlocked pool for Primary swap (same conversion rule).
-
-## Ammo Economy
-- Reserves are per‑weapon.
-- On swap: carry over floor(50% of previous Primary’s reserve) + new weapon’s default reserve.
-- Ammo pickups always feed the currently equipped weapon’s reserve.
-
-## Boss Rewards (every 5th wave)
-- Choose one smaller bonus:
-  - "Refine Primary" (minor per‑run buff; pick 1 of 2): +5% magazine OR −5% bloom OR +7% falloff range.
-  - "New Primary" (reroll with modest reserve): one choice; initial reserve = 1.25× default.
-- Guardrails: do not offer the same refine twice in a row; no stacking beyond +10% mag / −10% bloom / +15% falloff in a run.
-
-## Input and HUD
-- Keys: 1 = Primary, 2 = Sidearm.
-- HUD: show Primary name + icon; Sidearm icon smaller/dimmed.
-- Offer banner: “Armory Offer — press F” (compact, 10s timeout).
-- Crate prompt: “Weapon Crate — press E to open.”
-
-## Tuning Defaults
-- Offer schedule: even waves starting at 2.
-- Decline top‑up: +20% of current reserve (clamped by soft‑cap in `mechanics.md`).
-- Swap conversion: floor(0.5 × old reserve) + new default reserve.
-- Crate pity: +1%/wave without crate; reset on open; cap 1 per wave.
-- Boss “New Primary” reserve: 1.25× default; “Refine” caps as above.
+See `weapon-tiers.md` for current balance ranking of available weapons.


### PR DESCRIPTION
## Summary
- correct starting kit to pistol-only with SMG granted at wave 2
- enumerate all unlockable primaries and scripted early-armory offers
- note one-time sidearm offer and add reserve caps for minigun and grenade

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8794c8ab08322ad9d5e64b305b8fe