### PR TITLE
feat: respawn obstacles on milestone waves

### DIFF
--- a/src/enemies/manager.js
+++ b/src/enemies/manager.js
@@ -18,13 +18,14 @@ function containsExtrudeGeometry(obj){
 }
 
 export class EnemyManager {
-  constructor(THREE, scene, mats, objects = [], getPlayer = null, arenaRadius = Infinity) {
+  constructor(THREE, scene, mats, objects = [], getPlayer = null, arenaRadius = Infinity, obstacleManager = null) {
     this.THREE = THREE;
     this.scene = scene;
     this.mats = mats;
     this.objects = objects;
     this.getPlayer = getPlayer || (() => ({ position: new THREE.Vector3(), forward: new THREE.Vector3(0,0,1) }));
     this.arenaRadius = arenaRadius;
+    this.obstacleManager = obstacleManager;
     this.enemies = new Set();            // set of root meshes (raycast target) — back-compat
     this.instances = new Set();          // set of enemy instance objects
     this.instanceByRoot = new WeakMap(); // root -> instance
@@ -589,6 +590,10 @@ export class EnemyManager {
 
   startWave() {
     if (this.suspendWaves) return; // disabled in test harness
+    if (this.obstacleManager && this.wave % 5 === 0) {
+      const player = this.getPlayer();
+      try { this.obstacleManager.respawnMissing(player.position.clone(), this.enemies); } catch(_) {}
+    }
     // Gate boss waves
     if (this.wave % 5 === 0) {
       if (this.onWave) this.onWave(this.wave, 1);

--- a/src/main.js
+++ b/src/main.js
@@ -185,7 +185,8 @@ const enemyManager = new EnemyManager(
     const f = new THREE.Vector3(); camera.getWorldDirection(f); f.y = 0; f.normalize();
     return { position: pos, forward: f };
   },
-  arenaRadius
+  arenaRadius,
+  obstacleManager
 );
 // Ensure enemy manager colliders include arena floor and obstacles
 if (enemyManager.refreshColliders) enemyManager.refreshColliders(objects);

--- a/src/obstacles/destructible.js
+++ b/src/obstacles/destructible.js
@@ -1,7 +1,7 @@
 export class Destructible {
   constructor({ THREE, mats, type, position }) {
     this.THREE = THREE;
-    this.type = type; // 'crate' | 'barricade' | 'barrel'
+    this.type = type; // 'crate' | 'barricade' | 'barrel' | 'lowWall'
     this.hp = 1;
     this.root = null;
     this.aabbHalf = new THREE.Vector3(1,1,1);
@@ -27,7 +27,7 @@ export class Destructible {
         break;
       }
       case 'barricade': {
-        // 6x2x1 low wall
+        // 6x2x1 wall
         this.hp = 120;
         const g = new THREE.BoxGeometry(6, 2, 1);
         const m = mats?.wall || new THREE.MeshLambertMaterial({ color: 0x8ecae6 });
@@ -36,6 +36,18 @@ export class Destructible {
         mesh.castShadow = true; mesh.receiveShadow = true;
         this.root = mesh;
         this.aabbHalf.set(3, 1, 0.5);
+        break;
+      }
+      case 'lowWall': {
+        // 6x0.66x1 low wall that can be stepped over
+        this.hp = 40;
+        const g = new THREE.BoxGeometry(6, 0.66, 1);
+        const m = mats?.wall || new THREE.MeshLambertMaterial({ color: 0x8ecae6 });
+        const mesh = new THREE.Mesh(g, m);
+        mesh.position.copy(position || new THREE.Vector3());
+        mesh.castShadow = true; mesh.receiveShadow = true;
+        this.root = mesh;
+        this.aabbHalf.set(3, 0.33, 0.5);
         break;
       }
       case 'barrel':


### PR DESCRIPTION
## Summary
- track initial destructible count and respawn missing obstacles while skipping the player and living enemies
- trigger obstacle respawn every 5th wave before enemy spawning
- wire enemy manager to obstacle manager during initialization
- expose tryPlace with exclusion zones to keep new obstacles off players and living enemies
- introduce low wall destructible type and integrate it into obstacle spawning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a877065b288322b1bb352dbc20cd2d