### PR TITLE
Add god rays weather effect

### DIFF
--- a/src/godrays.js
+++ b/src/godrays.js
@@ -1,0 +1,55 @@
+// GodRaysEffect: simple wrapper around three.js GodRaysPass
+// Adds volumetric sun shafts ("god rays") for bright sunny weather
+import { EffectComposer } from 'https://unpkg.com/three@0.159.0/examples/jsm/postprocessing/EffectComposer.js?module';
+import { RenderPass } from 'https://unpkg.com/three@0.159.0/examples/jsm/postprocessing/RenderPass.js?module';
+import { GodRaysPass } from 'https://unpkg.com/three@0.159.0/examples/jsm/postprocessing/GodRaysPass.js?module';
+
+export class GodRaysEffect {
+  constructor({ THREE, renderer, scene, camera, light }) {
+    this.renderer = renderer;
+    this.scene = scene;
+    this.camera = camera;
+
+    // Create a small sphere to mark the sun position
+    const sunGeo = new THREE.SphereGeometry(4, 16, 8);
+    const sunMat = new THREE.MeshBasicMaterial({ color: 0xffee88 });
+    this.sun = new THREE.Mesh(sunGeo, sunMat);
+    if (light && light.position) {
+      this.sun.position.copy(light.position);
+    } else {
+      this.sun.position.set(20, 30, 10);
+    }
+    this.scene.add(this.sun);
+
+    // Post-processing setup
+    this.composer = new EffectComposer(this.renderer);
+    this.composer.addPass(new RenderPass(this.scene, this.camera));
+    this.godrays = new GodRaysPass(this.sun, this.camera, {
+      resolution: 256,
+      density: 0.96,
+      decay: 0.93,
+      weight: 0.4,
+      exposure: 0.6,
+      samples: 60,
+      clampMax: 1.0
+    });
+    this.composer.addPass(this.godrays);
+  }
+
+  render() {
+    this.composer.render();
+  }
+
+  setSize(w, h) {
+    this.composer.setSize(w, h);
+    if (this.godrays.setSize) this.godrays.setSize(w, h);
+  }
+
+  dispose() {
+    this.scene.remove(this.sun);
+    this.sun.geometry.dispose();
+    this.sun.material.dispose();
+    this.composer.dispose();
+  }
+}
+

--- a/test-weather.html
+++ b/test-weather.html
@@ -25,6 +25,7 @@
       <option value="fog">Fog</option>
       <option value="sandstorm">Sandstorm</option>
       <option value="windy">Windy</option>
+      <option value="godrays">God Rays</option>
     </select>
   </div>
   <script type="module">
@@ -33,6 +34,7 @@
     import { createWorld } from './src/world.js';
     import { WeatherSystem } from './src/weather.js';
     import { SFX } from './src/sfx.js';
+    import { GodRaysEffect } from './src/godrays.js';
 
     const { renderer, scene, camera, skyMat, hemi, dir, mats, grassMesh } = createWorld(THREE, Math.random);
     camera.position.set(0, 18, 36);
@@ -46,13 +48,22 @@
     controls.maxDistance = 80;
 
     const weather = new WeatherSystem({ THREE, scene, skyMat, hemi, dir, mats });
+    let godRays = null;
     weather._nextChangeAt = Infinity;
 
     const musicShim = { getContext(){ return new (window.AudioContext||window.webkitAudioContext)(); }, getFxBus(){ return null; } };
     window._SFX = new SFX({ audioContextProvider: ()=>musicShim.getContext(), fxBusProvider: ()=>musicShim.getFxBus() });
 
     const sel = document.getElementById('weatherSel');
-    const apply = ()=> weather.setMode(sel.value);
+    const apply = ()=>{
+      weather.setMode(sel.value);
+      if (sel.value === 'godrays'){
+        if (!godRays) godRays = new GodRaysEffect({ THREE, renderer, scene, camera, light: dir });
+      } else if (godRays){
+        godRays.dispose();
+        godRays = null;
+      }
+    };
     sel.addEventListener('change', apply);
     apply();
 
@@ -74,7 +85,7 @@
       grassMesh.material.uniforms.windStrength.value = 0.2 + 3.0 * windMix;
 
       skyMat.uniforms.time.value = t;
-      renderer.render(scene, camera);
+      if (godRays) godRays.render(); else renderer.render(scene, camera);
       requestAnimationFrame(loop);
     }
     requestAnimationFrame(loop);
@@ -83,6 +94,7 @@
       camera.aspect = window.innerWidth / window.innerHeight;
       camera.updateProjectionMatrix();
       renderer.setSize(window.innerWidth, window.innerHeight);
+      godRays?.setSize(window.innerWidth, window.innerHeight);
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add `GodRaysEffect` wrapper around Three.js GodRaysPass
- allow toggling god rays in test-weather demo

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aad08bd3588322ba2c577c6d184041