### PR TITLE
Preserve weapon slot when accepting sidearm

### DIFF
--- a/src/progression.js
+++ b/src/progression.js
@@ -274,9 +274,8 @@ export class Progression {
     if (pick?.sidearm){
       const cur = this.ws.inventory;
       const inst = pick.make();
-      if (cur.length === 1) cur.push(new (inst.constructor)());
-      else cur[1] = inst;
-      this.ws.currentIndex = Math.min(this.ws.currentIndex, 0);
+      if (cur.length === 1) cur.push(inst); else cur[1] = inst;
+      this.ws.currentIndex = Math.min(this.ws.currentIndex, this.ws.inventory.length - 1);
       this.ws.updateHUD?.();
       this._closeOffer(true);
       return;


### PR DESCRIPTION
## Summary
- allow keeping secondary slot selected when accepting a sidearm
- reuse created sidearm instance instead of constructing twice

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b59908a85c83228157e553aca69de8