### PR TITLE
Implement dynamic decline ammo refill

### DIFF
--- a/src/progression.js
+++ b/src/progression.js
@@ -264,9 +264,15 @@ export class Progression {
 
   // ---------- Accept / Decline ----------
   _decline(){
-    // +20% reserve to current primary
+    // adjust reserve ammo on decline
     const cur = this.ws.current;
-    if (cur) cur.addReserve(Math.floor((cur.getReserve() || 0) * 0.2));
+    if (cur){
+      const def = cur.cfg?.reserve || 0;
+      const current = cur.getReserve ? (cur.getReserve() || 0) : 0;
+      if (current < def * 0.5) cur.addReserve(def - current);
+      else cur.addReserve(Math.floor(def * 0.5));
+      this.ws.updateHUD?.();
+    }
     this._closeOffer(false);
   }
 

--- a/test/progression.test.js
+++ b/test/progression.test.js
@@ -101,3 +101,37 @@ test('sidearm offers exclude current sidearm', () => {
   assert.deepEqual(names.sort(), ['BeamSaber','Grenade']);
 });
 
+test('decline tops off low reserve', () => {
+  setupLocalStorage();
+  const doc = makeStubDoc();
+  let hud = 0;
+  const cur = {
+    cfg: { reserve: 100 },
+    reserve: 20,
+    getReserve(){ return this.reserve; },
+    addReserve(n){ this.reserve += n; }
+  };
+  const ws = { current: cur, updateHUD(){ hud += 1; } };
+  const p = new Progression({ weaponSystem: ws, documentRef: doc, onPause: () => {} });
+  p._decline();
+  assert.equal(cur.reserve, 100);
+  assert.equal(hud, 1);
+});
+
+test('decline grants 50% bonus at or above half reserve', () => {
+  setupLocalStorage();
+  const doc = makeStubDoc();
+  let hud = 0;
+  const cur = {
+    cfg: { reserve: 100 },
+    reserve: 60,
+    getReserve(){ return this.reserve; },
+    addReserve(n){ this.reserve += n; }
+  };
+  const ws = { current: cur, updateHUD(){ hud += 1; } };
+  const p = new Progression({ weaponSystem: ws, documentRef: doc, onPause: () => {} });
+  p._decline();
+  assert.equal(cur.reserve, 110);
+  assert.equal(hud, 1);
+});
+


### PR DESCRIPTION
## Summary
- Refill decline ammo from weapon's default reserve
- Refresh HUD after decline bonuses
- Add tests for low- and high-reserve decline cases

## Testing
- `npm test`
- `npm run lint`
- `npm run resource-check`


------
https://chatgpt.com/codex/tasks/task_e_68b59884b62c832289c9266c7f2ec569