### PR TITLE
Ensure primary slot active when presenting offer

### DIFF
--- a/src/progression.js
+++ b/src/progression.js
@@ -195,7 +195,9 @@ export class Progression {
       d.onclick = () => this._selectPick(p, d);
       this.choicesEl.appendChild(d);
     }
-
+    // Ensure the primary slot is active when presenting the offer
+    this.ws.switchSlot(1);
+    this.ws.updateHUD?.();
     this.offerEl.style.display = '';
     this.offerOpen = true;
     this.onPause(true);


### PR DESCRIPTION
## Summary
- Force weapon system to primary slot before showing upgrade offer
- Refresh HUD while switching slots to keep UI in sync

## Testing
- `npm test`
- `npm run lint`
- `npm run resource-check`


------
https://chatgpt.com/codex/tasks/task_e_68b5b421a27483228a5379d6c1c629e1